### PR TITLE
Fix typo in bootsnav.css comment

### DIFF
--- a/assets/css/bootsnav.css
+++ b/assets/css/bootsnav.css
@@ -206,7 +206,7 @@ li.close-full-menu{
     padding-bottom: 30px;
 }
 
-/* Atribute Navigation
+/* Attribute Navigation
 =================================*/
 .attr-nav{
     float: right;
@@ -700,7 +700,7 @@ body.on-side .wrap-sticky nav.navbar.bootsnav.sticked{
         display: block;
     }
     
-    /* Atribute Navigation
+    /* Attribute Navigation
     =================================*/    
     .attr-nav > ul > li.dropdown ul.dropdown-menu{
         margin-top: 0;


### PR DESCRIPTION
## Summary
- correct misspelled comments in `bootsnav.css`

## Testing
- `grep -n "Attribute Navigation" -n assets/css/bootsnav.css`

------
https://chatgpt.com/codex/tasks/task_b_685e303a3a4c8325965d3ee82bd336d1