### PR TITLE
Add Jest tests for room search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "personal-website",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/projects/Project1/__tests__/script.test.js
+++ b/projects/Project1/__tests__/script.test.js
@@ -1,0 +1,15 @@
+const { filterRooms } = require('../script');
+
+describe('filterRooms', () => {
+  const data = [
+    { Location: 'ADLER JOURNALISM', 'Room Number': '101', 'Building Number': 'AJB', Abbreviation: 'AJB' },
+    { Location: 'MAIN LIBRARY', 'Room Number': '201', 'Building Number': 'LIB', Abbreviation: 'LIB' },
+  ];
+
+  test('matches search term against multiple fields', () => {
+    const result = filterRooms(data, 'lib');
+    expect(result).toEqual([
+      { Location: 'MAIN LIBRARY', 'Room Number': '201', 'Building Number': 'LIB', Abbreviation: 'LIB' },
+    ]);
+  });
+});

--- a/projects/Project1/script.js
+++ b/projects/Project1/script.js
@@ -1,3 +1,16 @@
+// Helper used by both the page logic and Jest tests to filter rooms by a search
+// term.  The search is case insensitive and checks several fields on the room
+// object.
+function filterRooms(rooms, term) {
+  const searchTerm = term.toLowerCase();
+  return rooms.filter(room =>
+    room.Location.toLowerCase().includes(searchTerm) ||
+    room['Room Number'].toLowerCase().includes(searchTerm) ||
+    room['Building Number'].toLowerCase().includes(searchTerm) ||
+    room.Abbreviation.toLowerCase().includes(searchTerm)
+  );
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     const roomsList = document.getElementById('rooms-list');
     const searchBar = document.getElementById('search-bar');
@@ -297,25 +310,22 @@ document.addEventListener('DOMContentLoaded', function () {
       displayRooms(roomsData);
     
       searchBar.addEventListener('keyup', function () {
-        const searchTerm = searchBar.value.toLowerCase();
-        const filteredRooms = roomsData.filter(room => {
-          return (
-            room.Location.toLowerCase().includes(searchTerm) ||
-            room['Room Number'].toLowerCase().includes(searchTerm) ||
-            room['Building Number'].toLowerCase().includes(searchTerm) ||
-            room.Abbreviation.toLowerCase().includes(searchTerm)
-          );
-        });
+        const filteredRooms = filterRooms(roomsData, searchBar.value);
         displayRooms(filteredRooms);
       });
     });
     
-    function showDirections(index) {
-      const directionsDiv = document.getElementById(`directions-${index}`);
-      if (directionsDiv.style.display === 'none') {
-        directionsDiv.style.display = 'block';
-      } else {
-        directionsDiv.style.display = 'none';
-    }
+function showDirections(index) {
+  const directionsDiv = document.getElementById(`directions-${index}`);
+  if (directionsDiv.style.display === 'none') {
+    directionsDiv.style.display = 'block';
+  } else {
+    directionsDiv.style.display = 'none';
+  }
+}
+
+// Export for Jest testing in Node environments without affecting browser usage.
+if (typeof module !== 'undefined') {
+  module.exports = { filterRooms };
 }
     


### PR DESCRIPTION
## Summary
- add `filterRooms` helper and export for testing
- use helper when filtering rooms on keyup
- add Jest test for search logic
- initialize `package.json` and add Jest dependency
- ignore `node_modules`

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_b_685e303f55708325890445f731870055